### PR TITLE
Make n-o-d-e.net look good in small windows and on mobile phones. 

### DIFF
--- a/2017.html
+++ b/2017.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/alarm.html
+++ b/alarm.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/alexandria.html
+++ b/alexandria.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/arkos.html
+++ b/arkos.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/beacon.html
+++ b/beacon.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/biohacking.html
+++ b/biohacking.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/bitcoin.html
+++ b/bitcoin.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/bitcoinguard.html
+++ b/bitcoinguard.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/bitmessage.html
+++ b/bitmessage.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/block_ads.html
+++ b/block_ads.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/book.html
+++ b/book.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/brave.html
+++ b/brave.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/capcom.html
+++ b/capcom.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/casio.html
+++ b/casio.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/casio2.html
+++ b/casio2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd01.html
+++ b/cd01.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd02.html
+++ b/cd02.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd03.html
+++ b/cd03.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd04.html
+++ b/cd04.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd05.html
+++ b/cd05.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd06.html
+++ b/cd06.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd07.html
+++ b/cd07.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd08.html
+++ b/cd08.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd09.html
+++ b/cd09.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd10.html
+++ b/cd10.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd11.html
+++ b/cd11.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd12.html
+++ b/cd12.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd13.html
+++ b/cd13.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd14.html
+++ b/cd14.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd15.html
+++ b/cd15.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd16.html
+++ b/cd16.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd17.html
+++ b/cd17.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd18.html
+++ b/cd18.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd19.html
+++ b/cd19.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd20.html
+++ b/cd20.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd21.html
+++ b/cd21.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd22.html
+++ b/cd22.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd23.html
+++ b/cd23.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd24.html
+++ b/cd24.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd25.html
+++ b/cd25.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd26.html
+++ b/cd26.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd27.html
+++ b/cd27.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd28.html
+++ b/cd28.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd29.html
+++ b/cd29.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd30.html
+++ b/cd30.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd31.html
+++ b/cd31.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd32.html
+++ b/cd32.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd33.html
+++ b/cd33.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd34.html
+++ b/cd34.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd35.html
+++ b/cd35.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd36.html
+++ b/cd36.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd37.html
+++ b/cd37.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd38.html
+++ b/cd38.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd39.html
+++ b/cd39.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd40.html
+++ b/cd40.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd41.html
+++ b/cd41.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd42.html
+++ b/cd42.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd43.html
+++ b/cd43.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd44.html
+++ b/cd44.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd45.html
+++ b/cd45.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd46.html
+++ b/cd46.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd47.html
+++ b/cd47.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cd48.html
+++ b/cd48.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/charger.html
+++ b/charger.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/clearnet.html
+++ b/clearnet.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cli.html
+++ b/cli.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/cli2.html
+++ b/cli2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/command_line.html
+++ b/command_line.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/css/style.css
+++ b/css/style.css
@@ -48,3 +48,4 @@ img             {max-width: 100%; margin-bottom: 20px;}
 .description    {background: #1f1f1f; padding: 10px 0 10px 10px; margin-top: 0px;}
 .videowrapper   {position: relative; padding-bottom: 56.45%; height: 0;}
 .videowrapper iframe {position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,255,255,0);}
+@media screen and (max-width:750px) {#page{padding-left: 20px; padding-right: 20px;}}

--- a/cyberdeck64.html
+++ b/cyberdeck64.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/datt.html
+++ b/datt.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd01.html
+++ b/dd01.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd02.html
+++ b/dd02.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd03.html
+++ b/dd03.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd04.html
+++ b/dd04.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd05.html
+++ b/dd05.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd06.html
+++ b/dd06.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd07.html
+++ b/dd07.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd08.html
+++ b/dd08.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd09.html
+++ b/dd09.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd10.html
+++ b/dd10.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd11.html
+++ b/dd11.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd12.html
+++ b/dd12.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd13.html
+++ b/dd13.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd14.html
+++ b/dd14.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd15.html
+++ b/dd15.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd16.html
+++ b/dd16.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dd17.html
+++ b/dd17.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/deaddrops.html
+++ b/deaddrops.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/decentraland.html
+++ b/decentraland.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/decentraland2.html
+++ b/decentraland2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/decentraland3.html
+++ b/decentraland3.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/decentralized_world.html
+++ b/decentralized_world.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/decryption_effect.html
+++ b/decryption_effect.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/digital_nomadics.html
+++ b/digital_nomadics.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dongle.html
+++ b/dongle.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dongle2.html
+++ b/dongle2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dongle3.html
+++ b/dongle3.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/dongle_hdmi.html
+++ b/dongle_hdmi.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/doomsday_archive.html
+++ b/doomsday_archive.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/drone_racing.html
+++ b/drone_racing.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/duality.html
+++ b/duality.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/elementaryos.html
+++ b/elementaryos.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/emdrive.html
+++ b/emdrive.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/emdrive2.html
+++ b/emdrive2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/encrypt.html
+++ b/encrypt.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/encryption.html
+++ b/encryption.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/encryption_ban.html
+++ b/encryption_ban.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/ethernet.html
+++ b/ethernet.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/factory.html
+++ b/factory.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/faq.html
+++ b/faq.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/firefox.html
+++ b/firefox.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/funding.html
+++ b/funding.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/hyperboria.html
+++ b/hyperboria.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/i2p.html
+++ b/i2p.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@ Video archive:  https://archive.org/details/@n-o-d-e
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4"/>
     <link rel="shortcut icon" href="images/avatar.png">

--- a/isp.html
+++ b/isp.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/ledger_nano.html
+++ b/ledger_nano.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/machine_share.html
+++ b/machine_share.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/maidsafe.html
+++ b/maidsafe.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/memtype.html
+++ b/memtype.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/metadata.html
+++ b/metadata.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/micropayments.html
+++ b/micropayments.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/microsd.html
+++ b/microsd.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/multitool2.html
+++ b/multitool2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/nakamoto.html
+++ b/nakamoto.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/namecoin.html
+++ b/namecoin.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/neutrality.html
+++ b/neutrality.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/nightvision.html
+++ b/nightvision.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/node_updates.html
+++ b/node_updates.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/node_updates2.html
+++ b/node_updates2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/node_updates3.html
+++ b/node_updates3.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/node_updates4.html
+++ b/node_updates4.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/nutrition.html
+++ b/nutrition.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/opendime.html
+++ b/opendime.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/opendime2.html
+++ b/opendime2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/otg.html
+++ b/otg.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/p2p.html
+++ b/p2p.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/packet.html
+++ b/packet.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pass.html
+++ b/pass.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pgpasc.html
+++ b/pgpasc.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pi_zero_dongle.html
+++ b/pi_zero_dongle.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pipyramid.html
+++ b/pipyramid.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/piratebox.html
+++ b/piratebox.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pislim.html
+++ b/pislim.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/plainsight.html
+++ b/plainsight.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pocketnode.html
+++ b/pocketnode.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/pocketnodeguide.html
+++ b/pocketnodeguide.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/political_censorship.html
+++ b/political_censorship.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/power_case.html
+++ b/power_case.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/privacy.html
+++ b/privacy.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/reputation.html
+++ b/reputation.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/roboteconomy.html
+++ b/roboteconomy.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/sanctuary.html
+++ b/sanctuary.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/sanctuary_incentives.html
+++ b/sanctuary_incentives.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/sanctuary_technical.html
+++ b/sanctuary_technical.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/satoshi.html
+++ b/satoshi.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/selfdriving.html
+++ b/selfdriving.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/shop/index.html
+++ b/shop/index.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="../images/avatar.png">

--- a/sia.html
+++ b/sia.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/soldering.html
+++ b/soldering.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/space.html
+++ b/space.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/steganography.html
+++ b/steganography.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/tap.html
+++ b/tap.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/terminal.html
+++ b/terminal.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/terminal_2.html
+++ b/terminal_2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/terminal_2_overview.html
+++ b/terminal_2_overview.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/torch.html
+++ b/torch.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/ubuntu_laptop_how.html
+++ b/ubuntu_laptop_how.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/ubuntu_laptop_overview.html
+++ b/ubuntu_laptop_overview.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/ungoogle.html
+++ b/ungoogle.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/usbcondom.html
+++ b/usbcondom.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/usbcondom3.html
+++ b/usbcondom3.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/usbcondom4.html
+++ b/usbcondom4.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/usbpower.html
+++ b/usbpower.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/verify.html
+++ b/verify.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/vrhackspace.html
+++ b/vrhackspace.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/waybackpack.html
+++ b/waybackpack.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/wifi.html
+++ b/wifi.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/yacy.html
+++ b/yacy.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/youtubedl.html
+++ b/youtubedl.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/zamek.html
+++ b/zamek.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/zeronet.html
+++ b/zeronet.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/zeroterminal.html
+++ b/zeroterminal.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">

--- a/zeroterminal2.html
+++ b/zeroterminal2.html
@@ -12,6 +12,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>N O D E</title>
     <meta name="google-site-verification" content="KAh0wcTC2Anz5ea6Kq26RuhsiUKx5FD3D4HZAJdfaf4" />
     <link rel="shortcut icon" href="images/avatar.png">


### PR DESCRIPTION
Added a metatag and a css rule in a media query to make n-o-d-e.net work better in small windows and on mobile phones. If you use a program to generate n-o-d-e.net you'll obviously need to make these changes there instead of merging this.
Before:
![screenshot_20171010-090617](https://user-images.githubusercontent.com/7983745/31373555-d1319522-ad9a-11e7-874e-18c5090fdbf1.png)
After:
![screenshot_20171010-090625](https://user-images.githubusercontent.com/7983745/31373552-d10bd81e-ad9a-11e7-8179-cf3a80fcca4d.png)



